### PR TITLE
Update user info url for Todoist v8

### DIFF
--- a/lib/omniauth/strategies/todoist.rb
+++ b/lib/omniauth/strategies/todoist.rb
@@ -45,7 +45,7 @@ module OmniAuth
 
       def raw_info
         unless @raw_info
-          user_info = access_token.post("/API/v7/sync", { 
+          user_info = access_token.post("https://api.todoist.com/sync/v8/sync", {
             body: { 
               token: access_token.token, 
               sync_token: "*", 

--- a/lib/omniauth/todoist/version.rb
+++ b/lib/omniauth/todoist/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Todoist
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
This should fix the Beeminder "new auths to Todoists" fail bug.