### PR TITLE
Update sync API endpoint to v9

### DIFF
--- a/lib/omniauth/strategies/todoist.rb
+++ b/lib/omniauth/strategies/todoist.rb
@@ -26,7 +26,6 @@ module OmniAuth
         prune!(
           name:      raw_info['full_name'],
           email:     raw_info['email'],
-          phone:     raw_info['mobile_number'],
           image:     raw_info['avatar_big'],
           time_zone: raw_info['tz_info']['timezone']
         )
@@ -54,7 +53,7 @@ module OmniAuth
               resource_types: '["user"]'
             }
           }
-          access_token.post("https://api.todoist.com/sync/v8/sync", params).parsed.fetch('user', {})
+          access_token.post("https://api.todoist.com/sync/v9/sync", params).parsed.fetch('user', {})
         end
       end
 

--- a/lib/omniauth/todoist/version.rb
+++ b/lib/omniauth/todoist/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Todoist
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
V8 sync API endpoint has been deprecated and was advertised as removed as of Nov 30. See https://developer.todoist.com/sync/v8/\#overview.

V8 sync endpoint (https://api.todoist.com/sync/v8/sync/user), when called by Omniauth returns HTTP 410 (Gone).

`mobile_number` property of the `user` object had been already deprecated in v8 and has been removed in v9.